### PR TITLE
Refactor shader selection in CreateTransparentMaterial

### DIFF
--- a/Demosaic-il2cpp/demosaic-il2cpp.cs
+++ b/Demosaic-il2cpp/demosaic-il2cpp.cs
@@ -172,36 +172,53 @@ namespace DemosaicPlugin
             methodDisableKeywordList = ParseKeywordString(methodDisableKeywords.Value);
         }
 
-        private void CreateTransparentMaterial()
+    private void CreateTransparentMaterial()
+    {
+        string[] shaderNames =
         {
-            // 优先尝试 URP 着色器，然后回退到 HDRP，最后回退到 Standard
-            Shader shader = Shader.Find("Universal Render Pipeline/Lit");
-            transparentShaderIsURP = shader != null;
+            "Sprites/Default",
+            "UI/Default",
+            "Unlit/Transparent",
+            "Spine/Skeleton",
+            "Universal Render Pipeline/Lit",
+            "HDRP/Lit",
+            "HD Render Pipeline/Lit",
+            "Standard"
+        };
 
-            if (shader == null)
-            {
-                shader = Shader.Find("HDRP/Lit");
-                if (shader == null)
-                    shader = Shader.Find("HD Render Pipeline/Lit");
-            }
+        Shader shader = null;
 
-            if (shader == null)
-                shader = Shader.Find("Standard");
-
+        foreach (var name in shaderNames)
+        {
+            shader = Shader.Find(name);
             if (shader != null)
             {
-                transparentShader = shader;
-                transparentMaterial = CreateTransparentMaterialFromShader(shader, transparentShaderIsURP);
-                Logger.LogInfo($"透明材质创建成功，使用着色器: {shader.name}");
-            }
-            else
-            {
-                Logger.LogError("未能找到 URP Lit、HDRP Lit 或 Standard 着色器。透明模式将无法正常工作。");
+                Logger.LogInfo($"找到透明Shader: {shader.name}");
+                break;
             }
         }
 
+        if (shader == null)
+        {
+            Logger.LogError("无法找到任何可用Shader。");
+            return;
+        }
+
+        transparentShader = shader;
+        transparentShaderIsURP = shader.name.Contains("Universal");
+
+        transparentMaterial = CreateTransparentMaterialFromShader(shader, transparentShaderIsURP);
+    }
+
         private Material CreateTransparentMaterialFromShader(Shader shader, bool isURP)
         {
+            if (shader.name == "Sprites/Default")
+            {
+                var mat1 = new Material(shader);
+                mat1.hideFlags = HideFlags.HideAndDontSave;
+                mat1.color = new Color(1f,1f,1f,0f);
+                return mat1;
+            }
             var mat = new Material(shader);
             // 防止 Unity GC 回收
             mat.hideFlags = HideFlags.HideAndDontSave;


### PR DESCRIPTION
1. 扩展透明材质可用 Shader 的查找范围
    部分 Built-in Render Pipeline 游戏为了减小包体，会裁剪 Standard Shader，导致无法创建透明材质，Smart 模式最终会降级为 Disable，导致马赛克材质所在的整个对象被禁用。修改后按顺序尝试更多个常见 Shader，日后也可继续按需添加，只要游戏中存在其中任意一个 Shader，即可正常创建透明材质，提升了不同 Unity 项目的兼容性。
2. 为 Sprites/Default 添加透明材质特殊处理
    Sprites/Default 与 Standard/URP/HDRP 的材质属性不同，不支持 _Mode、_Surface 等属性。
因此新增针对 Sprites/Default 的处理逻辑，直接创建材质并将颜色 Alpha 设置为 0。避免因属性不存在导致透明材质创建失败。